### PR TITLE
Support older Apple platforms

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -21,10 +21,10 @@
     {
       "identity" : "swift-hash",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tayloraswift/swift-hash",
+      "location" : "https://github.com/stackotter/swift-hash",
       "state" : {
-        "revision" : "7798c344afd5a96b689fa9904ad52242a85b5068",
-        "version" : "0.6.0"
+        "revision" : "6e9301937718c3c0b2ce6bfd323a210a7490a007",
+        "version" : "0.6.3"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -21,9 +21,9 @@
     {
       "identity" : "swift-hash",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stackotter/swift-hash",
+      "location" : "https://github.com/tayloraswift/swift-hash",
       "state" : {
-        "revision" : "6e9301937718c3c0b2ce6bfd323a210a7490a007",
+        "revision" : "4d70a941b7039358f2ec8565f6c3b53c05f6c6ef",
         "version" : "0.6.3"
       }
     }

--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package:Package = .init(name: "swift-png",
-    platforms: [.macOS("13.3"), .iOS("16.4"), .tvOS("16.4"), .watchOS("9.4")],
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
     products: [
         .library(name: "LZ77", targets: ["LZ77"]),
         .library(name: "PNG", targets: ["PNG"]),
@@ -11,8 +11,8 @@ let package:Package = .init(name: "swift-png",
         .executable(name: "decompression-benchmark", targets: ["PNGDecompressionBenchmarks"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tayloraswift/swift-hash", .upToNextMinor(
-            from: "0.6.0")),
+        .package(url: "https://github.com/stackotter/swift-hash", .upToNextMinor(
+            from: "0.6.3")),
         .package(url: "https://github.com/tayloraswift/swift-grammar", .upToNextMinor(
             from: "0.4.0")),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package:Package = .init(name: "swift-png",
         .executable(name: "decompression-benchmark", targets: ["PNGDecompressionBenchmarks"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/stackotter/swift-hash", .upToNextMinor(
+        .package(url: "https://github.com/tayloraswift/swift-hash", .upToNextMinor(
             from: "0.6.3")),
         .package(url: "https://github.com/tayloraswift/swift-grammar", .upToNextMinor(
             from: "0.4.0")),


### PR DESCRIPTION
This is a companion to [the recently merged swift-hash PR](https://github.com/tayloraswift/swift-hash/pull/18). It bumps the required swift-hash version and lowers the Apple platform requirements in `Package.swift` accordingly.

Adresses #74.