### PR TITLE
Debug mode performance improvements

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -21,10 +21,10 @@
     {
       "identity" : "swift-hash",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tayloraswift/swift-hash",
+      "location" : "https://github.com/stackotter/swift-hash",
       "state" : {
-        "revision" : "4d70a941b7039358f2ec8565f6c3b53c05f6c6ef",
-        "version" : "0.6.3"
+        "revision" : "7151d95817516d96509fdfeb3faaa92f273df47f",
+        "version" : "0.6.4"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package:Package = .init(name: "swift-png",
         .executable(name: "decompression-benchmark", targets: ["PNGDecompressionBenchmarks"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/stackotter/swift-hash", revision: "7151d95"),
+        .package(url: "https://github.com/stackotter/swift-hash", .upToNextMinor(from: "0.6.4")),
         .package(url: "https://github.com/tayloraswift/swift-grammar", .upToNextMinor(
             from: "0.4.0")),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,7 @@ let package:Package = .init(name: "swift-png",
         .executable(name: "decompression-benchmark", targets: ["PNGDecompressionBenchmarks"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tayloraswift/swift-hash", .upToNextMinor(
-            from: "0.6.3")),
+        .package(url: "https://github.com/stackotter/swift-hash", revision: "7151d95"),
         .package(url: "https://github.com/tayloraswift/swift-grammar", .upToNextMinor(
             from: "0.4.0")),
     ],

--- a/Sources/LZ77/HuffmanCoding/LZ77.Distance.swift
+++ b/Sources/LZ77/HuffmanCoding/LZ77.Distance.swift
@@ -21,10 +21,38 @@ extension LZ77.Distance
 {
     var decade:Int
     {
-        .init(self.storage & 0x00ff)
+        let value = self.storage & 0x00ff
+        #if DEBUG
+            // this hacky integer conversion makes this function about 17x faster in
+            // debug mode. cause of Int, we have to handle both 32-bit and 64-bit
+            // systems separately.
+            if MemoryLayout<Int>.stride == 8 {
+                let tuple:(UInt16, UInt16, UInt16, UInt16) = (value, 0, 0, 0)
+                return unsafeBitCast(tuple, to: Int.self)
+            } else {
+                let tuple:(UInt16, UInt16) = (value, 0)
+                return unsafeBitCast(tuple, to: Int.self)
+            }
+        #else
+            return .init(value)
+        #endif
     }
     var length:Int
     {
-        .init(self.storage >> 8)
+        let value = self.storage >> 8
+        #if DEBUG
+            // this hacky integer conversion makes this function about 24x faster in
+            // debug mode. cause of Int, we have to handle both 32-bit and 64-bit
+            // systems separately.
+            if MemoryLayout<Int>.stride == 8 {
+                let tuple:(UInt16, UInt16, UInt16, UInt16) = (value, 0, 0, 0)
+                return unsafeBitCast(tuple, to: Int.self)
+            } else {
+                let tuple:(UInt16, UInt16) = (value, 0)
+                return unsafeBitCast(tuple, to: Int.self)
+            }
+        #else
+            return .init(value)
+        #endif
     }
 }

--- a/Sources/LZ77/HuffmanCoding/LZ77.RunLiteral.swift
+++ b/Sources/LZ77/HuffmanCoding/LZ77.RunLiteral.swift
@@ -27,10 +27,38 @@ extension LZ77.RunLiteral
     }
     var decade:Int
     {
-        .init(self.storage & 0b0000_0000_1111_1111)
+        let value = self.storage & 0b0000_0000_1111_1111
+        #if DEBUG
+            // this hacky integer conversion makes this function about 12x faster in
+            // debug mode. cause of Int, we have to handle both 32-bit and 64-bit
+            // systems separately.
+            if MemoryLayout<Int>.stride == 8 {
+                let tuple:(UInt16, UInt16, UInt16, UInt16) = (value, 0, 0, 0)
+                return unsafeBitCast(tuple, to: Int.self)
+            } else {
+                let tuple:(UInt16, UInt16) = (value, 0)
+                return unsafeBitCast(tuple, to: Int.self)
+            }
+        #else
+            return .init(value)
+        #endif
     }
     var length:Int
     {
-        .init(self.storage >> 12)
+        let value = self.storage >> 12
+        #if DEBUG
+            // this hacky integer conversion makes this function about 27x faster in
+            // debug mode. cause of Int, we have to handle both 32-bit and 64-bit
+            // systems separately.
+            if MemoryLayout<Int>.stride == 8 {
+                let tuple:(UInt16, UInt16, UInt16, UInt16) = (value, 0, 0, 0)
+                return unsafeBitCast(tuple, to: Int.self)
+            } else {
+                let tuple:(UInt16, UInt16) = (value, 0)
+                return unsafeBitCast(tuple, to: Int.self)
+            }
+        #else
+            return .init(value)
+        #endif
     }
 }

--- a/Sources/LZ77/Inflator/LZ77.InflatorBuffers.Stream.swift
+++ b/Sources/LZ77/Inflator/LZ77.InflatorBuffers.Stream.swift
@@ -320,10 +320,23 @@ extension LZ77.InflatorBuffers.Stream
                 // (in the low bits bits of a UInt64)
                 // we put it in the low bits so that we can do masking shifts instead
                 // of checked shifts
-                var slug:UInt64 =
-                    .init(self.input[self.b + 32]) << 32 |
-                    .init(self.input[self.b + 16]) << 16 |
-                    .init(first)
+                #if DEBUG
+                    // this hacky integer conversion is quite a bit faster in debug mode
+                    // than the one using the `UInt64` initializer.
+                    let slugTuple:(UInt16, UInt16, UInt16, UInt16) =
+                    (
+                        first,
+                        self.input[self.b + 16],
+                        self.input[self.b + 32],
+                        0
+                    )
+                    var slug:UInt64 = unsafeBitCast(slugTuple, to: UInt64.self)
+                #else
+                    var slug:UInt64 =
+                        .init(self.input[self.b + 32]) << 32 |
+                        .init(self.input[self.b + 16]) << 16 |
+                        .init(first)
+                #endif
                 slug &>>= runliteral.length
 
                 let composite:

--- a/Sources/LZ77/Inflator/LZ77.InflatorIn.swift
+++ b/Sources/LZ77/Inflator/LZ77.InflatorIn.swift
@@ -127,8 +127,19 @@ extension LZ77.InflatorIn
                 var j:Int = 0
                 while j < iters
                 {
-                    $0[i &+          j]   = .init(start[j << 1 | 1]) << 8 |
-                                            .init(start[j << 1    ])
+                    let upper:UInt8 = start[j << 1 | 1]
+                    let lower:UInt8 = start[j << 1    ]
+                    let value:UInt16
+                    #if DEBUG
+                        // in debug mode this hacky integer conversion makes
+                        // LZ77.InflatorIn.rebase(_:pointer:) about 26x faster
+                        let tuple:(UInt8, UInt8) = (lower, upper)
+                        value = unsafeBitCast(tuple, to: UInt16.self)
+                    #else
+                        value = .init(upper) << 8 |
+                                .init(lower)
+                    #endif
+                    $0[i &+ j] = value
                     j += 1
                 }
                 let k:Int = i + (count + 1) >> 1

--- a/Sources/LZ77/Inflator/LZ77.InflatorIn.swift
+++ b/Sources/LZ77/Inflator/LZ77.InflatorIn.swift
@@ -117,10 +117,19 @@ extension LZ77.InflatorIn
                     count       = data.count
                 }
 
-                for j:Int in 0 ..< count >> 1
+                // in debug mode, the majority of the time spent in the for loop is
+                // spent in the iterator implemenation for Range<Int>. so in debug
+                // mode we use a manual while loop. when first introduced, this change made
+                // LZ77.InflatorIn.rebase(_:pointer:) about 4.5x faster. this change didn't
+                // affect release mode performance at all, so we just use it for both debug
+                // mode and release mode.
+                let iters:Int = count >> 1
+                var j:Int = 0
+                while j < iters
                 {
                     $0[i &+          j]   = .init(start[j << 1 | 1]) << 8 |
                                             .init(start[j << 1    ])
+                    j += 1
                 }
                 let k:Int = i + (count + 1) >> 1
                 if count & 1 != 0

--- a/Sources/LZ77/Inflator/LZ77.InflatorOut.swift
+++ b/Sources/LZ77/Inflator/LZ77.InflatorOut.swift
@@ -130,9 +130,12 @@ extension LZ77.InflatorOut
             // cannot use update(from:count:) because the standard library implementation
             // copies from the back to the front if the ranges overlap
             // https://github.com/apple/swift/blob/master/stdlib/public/core/UnsafePointer.swift#L745
-            for current:UnsafeMutablePointer<UInt8> in start ..< start + count
+            var i:Int = 0
+            while i < count
             {
+                let current:UnsafeMutablePointer<UInt8> = start + i
                 current.pointee = (current - offset).pointee
+                i += 1
             }
         }
         self.endIndex &+= count

--- a/Sources/LZ77/Inflator/LZ77.InflatorTables.swift
+++ b/Sources/LZ77/Inflator/LZ77.InflatorTables.swift
@@ -168,7 +168,25 @@ extension LZ77.InflatorTables
             let offset:Int          = 256 &+
                 MemoryLayout<Composite>.stride &* runliteral.decade
             let composite:Composite = raw.load(fromByteOffset: offset, as: Composite.self)
-            return (extra: .init(composite.extra), base: .init(composite.base))
+            #if DEBUG
+                if MemoryLayout<Int>.stride == 8 {
+                    let extraTuple:(UInt16, UInt16, UInt16, UInt16) = (composite.extra, 0, 0, 0)
+                    let baseTuple:(UInt16, UInt16, UInt16, UInt16) = (composite.base, 0, 0, 0)
+                    return (
+                        extra: unsafeBitCast(extraTuple, to: Int.self),
+                        base: unsafeBitCast(baseTuple, to: Int.self)
+                    )
+                } else {
+                    let extraTuple:(UInt16, UInt16) = (composite.extra, 0)
+                    let baseTuple:(UInt16, UInt16) = (composite.base, 0)
+                    return (
+                        extra: unsafeBitCast(extraTuple, to: Int.self),
+                        base: unsafeBitCast(baseTuple, to: Int.self)
+                    )
+                }
+            #else
+                return (extra: .init(composite.extra), base: .init(composite.base))
+            #endif
         }
     }
     func composite(decade distance:LZ77.Distance) -> (extra:Int, base:Int)
@@ -180,7 +198,25 @@ extension LZ77.InflatorTables
             let offset:Int          = (256 + 32 * MemoryLayout<Composite>.stride) &+
                 MemoryLayout<Composite>.stride &* distance.decade
             let composite:Composite = raw.load(fromByteOffset: offset, as: Composite.self)
-            return (extra: .init(composite.extra), base: .init(composite.base))
+            #if DEBUG
+                if MemoryLayout<Int>.stride == 8 {
+                    let extraTuple:(UInt16, UInt16, UInt16, UInt16) = (composite.extra, 0, 0, 0)
+                    let baseTuple:(UInt16, UInt16, UInt16, UInt16) = (composite.base, 0, 0, 0)
+                    return (
+                        extra: unsafeBitCast(extraTuple, to: Int.self),
+                        base: unsafeBitCast(baseTuple, to: Int.self)
+                    )
+                } else {
+                    let extraTuple:(UInt16, UInt16) = (composite.extra, 0)
+                    let baseTuple:(UInt16, UInt16) = (composite.base, 0)
+                    return (
+                        extra: unsafeBitCast(extraTuple, to: Int.self),
+                        base: unsafeBitCast(baseTuple, to: Int.self)
+                    )
+                }
+            #else
+                return (extra: .init(composite.extra), base: .init(composite.base))
+            #endif
         }
     }
 

--- a/Sources/LZ77/Inflator/LZ77.InflatorTables.swift
+++ b/Sources/LZ77/Inflator/LZ77.InflatorTables.swift
@@ -106,7 +106,26 @@ extension LZ77.InflatorTables
         // now i know why everyone at apple asks this same coding interview question
         self.storage.withUnsafeMutablePointerToElements
         {
-            .init($0[.init(byte)])
+            #if DEBUG
+                // these hacky integer conversions make this function about 7x faster in
+                // debug mode. cause of Int, we have to handle both 32-bit and 64-bit
+                // systems separately.
+                if MemoryLayout<Int>.stride == 8 {
+                    let indexTuple:(UInt16, UInt16, UInt16, UInt16) = (byte, 0, 0, 0)
+                    let index = unsafeBitCast(indexTuple, to: Int.self)
+                    let value = $0[index]
+                    let valueTuple:(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) = (value, 0, 0, 0, 0, 0, 0, 0)
+                    return unsafeBitCast(valueTuple, to: Int.self)
+                } else {
+                    let indexTuple:(UInt16, UInt16) = (byte, 0)
+                    let index = unsafeBitCast(indexTuple, to: Int.self)
+                    let value = $0[index]
+                    let valueTuple:(UInt8, UInt8, UInt8, UInt8) = (value, 0, 0, 0)
+                    return unsafeBitCast(valueTuple, to: Int.self)
+                }
+            #else
+                .init($0[.init(byte)])
+            #endif
         }
     }
     private

--- a/Sources/LZ77/Wrappers/LZ77.MRC32.swift
+++ b/Sources/LZ77/Wrappers/LZ77.MRC32.swift
@@ -32,7 +32,14 @@ extension LZ77.MRC32:LZ77.StreamIntegral
             var j:Int = 5552 * i
             while j < 5552 * (i + 1)
             {
-                self.single &+= .init(start[j])
+                #if DEBUG
+                    // these hacky integer conversions make MRC32.update(from:count:)
+                    // about 9x faster in debug mode.
+                    let singleTuple:(UInt8, UInt8, UInt8, UInt8) = (start[j], 0, 0, 0)
+                    self.single &+= unsafeBitCast(singleTuple, to: UInt32.self)
+                #else
+                    self.single &+= .init(start[j])
+                #endif
                 self.double &+= self.single
                 j += 1
             }
@@ -43,7 +50,12 @@ extension LZ77.MRC32:LZ77.StreamIntegral
         var j:Int = 5552 * q
         while j < 5552 * q + r
         {
-            self.single &+= .init(start[j])
+            #if DEBUG
+                let singleTuple:(UInt8, UInt8, UInt8, UInt8) = (start[j], 0, 0, 0)
+                self.single &+= unsafeBitCast(singleTuple, to: UInt32.self)
+            #else
+                self.single &+= .init(start[j])
+            #endif
             self.double &+= self.single
             j += 1
         }

--- a/Sources/LZ77/Wrappers/LZ77.MRC32.swift
+++ b/Sources/LZ77/Wrappers/LZ77.MRC32.swift
@@ -26,20 +26,26 @@ extension LZ77.MRC32:LZ77.StreamIntegral
     func update(from start:UnsafePointer<UInt8>, count:Int)
     {
         let (q, r):(Int, Int) = count.quotientAndRemainder(dividingBy: 5552)
-        for i:Int in 0 ..< q
+        var i:Int = 0
+        while i < q
         {
-            for j:Int in 5552 * i ..< 5552 * (i + 1)
+            var j:Int = 5552 * i
+            while j < 5552 * (i + 1)
             {
                 self.single &+= .init(start[j])
                 self.double &+= self.single
+                j += 1
             }
             self.single %= 65521
             self.double %= 65521
+            i += 1
         }
-        for j:Int in 5552 * q ..< 5552 * q + r
+        var j:Int = 5552 * q
+        while j < 5552 * q + r
         {
             self.single &+= .init(start[j])
             self.double &+= self.single
+            j += 1
         }
 
         self.single %= 65521

--- a/Sources/PNG/Decoding/PNG.Decoder.swift
+++ b/Sources/PNG/Decoding/PNG.Decoder.swift
@@ -151,43 +151,54 @@ extension PNG.Decoder
     static
     func defilter(_ line:inout [UInt8], last:[UInt8], delay:Int)
     {
-        let indices:Range<Int> = line.indices.dropFirst()
+        let dataStartIndex = line.startIndex + 1
+        let endIndex = line.endIndex
         switch line[line.startIndex]
         {
         case 0:
             break
 
         case 1: // sub
-            for i:Int in indices.dropFirst(delay)
+            var i:Int = dataStartIndex + delay
+            while i < endIndex
             {
                 line[i] &+= line[i &- delay]
+                i += 1
             }
 
         case 2: // up
-            for i:Int in indices
+            var i:Int = dataStartIndex
+            while i < endIndex
             {
                 line[i] &+= last[i]
+                i += 1
             }
 
         case 3: // average
-            for i:Int in indices.prefix(delay)
+            var i:Int = dataStartIndex
+            while i < dataStartIndex + delay
             {
                 line[i] &+= last[i] >> 1
+                i += 1
             }
-            for i:Int in indices.dropFirst(delay)
+            while i < endIndex
             {
                 let total:UInt16 = .init(line[i &- delay]) &+ .init(last[i])
                 line[i] &+= .init(total >> 1)
+                i += 1
             }
 
         case 4: // paeth
-            for i:Int in indices.prefix(delay)
+            var i:Int = dataStartIndex
+            while i < dataStartIndex + delay
             {
                 line[i] &+= PNG.paeth(0,                last[i], 0)
+                i += 1
             }
-            for i:Int in indices.dropFirst(delay)
+            while i < endIndex
             {
                 line[i] &+= PNG.paeth(line[i &- delay], last[i], last[i &- delay])
+                i += 1
             }
 
         default:

--- a/Sources/PNG/PNG.swift
+++ b/Sources/PNG/PNG.swift
@@ -132,20 +132,17 @@ extension PNG
         }
 
         #if DEBUG
-            // in debug mode this manual UInt8 -> Int16 code makes `paeth` approximately 270x
-            // faster than using either `Int16(x)` or `Int16(bitPattern: UInt16(x))`. without
+            // in debug mode this manual UInt8 -> Int16 code makes `paeth` approximately 7x
+            // faster than using either `Int16(x)` or `Int16(bitPattern: UInt16(x))`. before
             // this, paeth often took up around 10% of the time taken during decoding large images.
             // the regular Int16/UInt16 initialisers aren't specialised in debug mode and end up
             // spending most of their time reading generic metadata and checking stack canaries.
-            @inline(__always)
+            // hand unrolling the calls to this function has minimal effect on debug mode
+            // performance.
             func customUInt8ToInt16(_ x: UInt8) -> Int16
             {
                 let tuple:(UInt8, UInt8) = (x, 0)
-                let unsigned = withUnsafePointer(to: tuple)
-                {
-                    $0.withMemoryRebound(to: UInt16.self, capacity: 1) { $0.pointee }
-                }
-                return Int16(bitPattern: unsigned)
+                return unsafeBitCast(tuple, to: Int16.self)
             }
 
             let v:(Int16, Int16, Int16) =


### PR DESCRIPTION
## Context
While developing [swift-image-formats](https://github.com/stackotter/swift-image-formats) as part of the SwiftCrossUI project, I found the need to improve the performance of Swift PNG under debug mode. During my original testing I had only been using 16x16 test images. I discovered the issue when loading a 1544x596 png file took 4 seconds in debug mode. The reason that I need debug mode performance specifically is that SwiftCrossUI is distributed as a source code library so it gets compiled at the same optimisation level as the rest of an app's code; and it'd be unreasonable to expect all users of SwiftCrossUI to build their apps in release mode at all times. Ideally SwiftPM would allow users to override the default build configuration for specific dependencies, but until then I need to focus on debug mode performance.

For the large test image I used (see below) I managed to get loading the image down from 28.1 seconds to 4.16 seconds on average in debug mode. None of my code changes have affected release mode performance. In many cases I only applied my changes for debug mode, because in release mode the original code compiled better (because it had more semantic information for the compiler I guess).

During optimisation I took notes which I've included below with the hope that they can be of use to a future contributor to `swift-png` or a similar library which needs to improve its debug mode performance.

Related to #26

---

## Test image
I decided to up the ante and use quite a big image as my test image to get more samples in the profiler. This image is 3440x1440 pixels and its file is 10.5mb.

![wide_screenshot](https://github.com/user-attachments/assets/e6a5df92-857e-4079-a952-5c5984a824b8)

## Measurement technique
I'm testing performance from a test within `swift-image-formats`. I'm measuring two things; Swift PNG's decoding code, and `swift-image-formats`' pixel unpacking code which converts Swift PNG's pixel format to `swift-image-formats`' RGBA format.

## Approach
First I'll attempt to completely eliminate the unpacking step by implementing Swift PNG's pixel format protocol for `swift-image-formats`' `RGBA` type. Then I'll let the profiler guide me to slow code paths.

## Initial measurements for my original smaller image
- Debug: 2.88 seconds to load, 0.676 seconds to unpack
- Release: 0.00934 seconds to load, 0.00520 seconds to unpack

## Initial measurements
- Debug: 28.1 seconds to load, 3.80 seconds to unpack
- Release: 0.168 seconds to load, 0.0280 seconds to unpack

## With unpacking fast-path
I implemented `PNG.Color` for `swift-image-formats`' `RGBA` type and added a short circuit which can be taken when the PNG file was already using the `.rgba8` pixel format, in which case nothing has to be done.
- Debug: 28.0 seconds to load, 0.00000095 seconds to unpack
- Release: 0.165 seconds to load, 0.00000191 seconds to unpack
From now on I'll stop including the unpacking measurements since that's now essentially a no-op.

## With optimised `PNG.paeth(_:_:_:)`
In the previous profile, the relatively simple `PNG.paeth(_:_:_:)` function took up around 3.1 seconds total in debug mode (almost 10% of the total decoding time). Most of this time was spent converting `UInt8` values to `Int16` due to parsing generic metadata and doing stack checks for something which should really just be one operation even in debug mode. I made a manual conversion implementation that seems to compile pretty well even in debug mode. `PNG.paeth(_:_:_:)` now only takes about 440 milliseconds total.
- Debug: 25.9 seconds
- Release: 0.175 seconds
Although the numbers make it seem as if this change made the implementation slower in release mode, I double checked and the previous version is also running slower today so I think it's just caused by variations in conditions. However, `Int16(_:)` always compiles down to a single instruction in release mode so we may as well use that in release mode just in case.

## Manually implemented for loop for `LZ77.InflatorIn.rebase(_:pointer:)`
About 70% of the 1.38 seconds total spent in this function was spent calling `IndexingIterator.next` on the range getting iterated over in a for loop. By using a while loop with a manual counter variable instead of a for loop, this overhead got completely eliminated in debug mode. The function now only takes up 309 milliseconds of the decoding process.
- Debug: 24.3 seconds
- Release: 0.170 seconds (probably just variation in testing conditions)

## Manually implemented for loops for `PNG.Decoder.defilter(_:last:delay:)`
Exact same idea as previous improvement.
- Debug: 20.4 seconds
- Release: 0.171 seconds

## Manually implemented for loops for `LZ77.MRC32.update(from:count:)`
- Debug: 16.3 seconds
- Release: 0.174 seconds

## Manually implemented for loop for `LZ77.InflatorOut.expand(offset:count:)`
Now we're 2x faster than when I started!
- Debug: 12.13 seconds
- Release: 0.171 seconds

## Manually implemented for loop for `PNG.Image.assign(scanline:at:stride:)`
- Debug: 11.44 seconds
- Release: 0.171 seconds

## Manually implemented `UInt16, UInt16` to `UInt32` conversion for `LZ77.InflatorIn.subscript` implementations
**TODO**: Is this code portable to big endian? Do we need it to be portable to big endian?
- Debug: 10.45 seconds
- Release: 0.172 seconds

## Manually implemented integer conversions for `LZ77.InflatorTables.reverse(_:)`
We're now 3x faster in debug mode than when I started!
- Debug: 9.15 seconds
- Release: 0.173 seconds

## Manually implemented integer conversions for `LZ77.InflatorTables.composite(_:)`
- Debug: 8.37 seconds
- Release: 0.170 seconds

## Manually implemented integer conversions for `LZ77.MRC32.update(from:count:)`
- Debug: 7.85 seconds
- Release: 0.173 seconds

## Manually implemented integer conversions for `LZ77.InflatorBuffers.readBlock(with:)`
- Debug: 7.36 seconds
- Release: 0.172 seconds

## Manually implemented integer conversions for `LZ77.RunLiteral.length`
We're 4x faster in debug mode than when I started now!
- Debug: 6.716 seconds
- Release: 0.171 seconds

## Manually implemented integer conversions for `LZ77.InflatorIn.rebase(_:pointer:)`
- Debug: 6.32 seconds
- Release: 0.171 seconds

## Manually implemented integer conversions for `LZ77.Distance` computed properties
- Debug: 5.72 seconds
- Release: 0.171 seconds

## Manually implemented integer conversions for `LZ77.RunLiteral.decade`
- Debug: 5.45 seconds
- Release: 0.171 seconds

## Manually implemented integer conversions for `CRC32.update(with:)` (in `swift-hash`)
- Debug: 4.96 seconds
- Release: 0.171 seconds

## Manually specialised `CRC32.update(with:)` for `[UInt8]` without `reduce`
- Debug: 4.45 seconds
- Release: 0.171 seconds

## Manually implemented `FixedWidthInteger.init(truncatingIfNeeded:)` for `PNG.paeth`
- Debug: 4.16 seconds
- Release: 0.171 seconds