### PR TITLE
Restore Android CI workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,3 +18,4 @@ jobs:
                 uses: skiptools/swift-android-action@main
                 with:
                     swift-version: 6.1
+                    copy-files: Sources

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,6 +15,6 @@ jobs:
             -   name: Checkout repository
                 uses: actions/checkout@v4
             -   name: Build for Android
-                uses: skiptools/swift-android-action@v2
+                uses: skiptools/swift-android-action@main
                 with:
-                    run-tests: false
+                    swift-version: 6.1

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,4 +18,4 @@ jobs:
                 uses: skiptools/swift-android-action@main
                 with:
                     swift-version: 6.1
-                    copy-files: Sources
+                    copy-files: Sources Tests


### PR DESCRIPTION
My Android CI (https://github.com/tayloraswift/swift-png/pull/84) was disabled in the adoption of Swift testing (https://github.com/tayloraswift/swift-png/pull/85) because [swift-android-action](https://github.com/marketplace/actions/swift-android-action) didn't support the Testing framework. But it does now, for 6.1+ toolchains. This PR re-enables it, and the tests are running and passing in [my fork's CI](https://github.com/marcprux/swift-png/actions/runs/13823456678).